### PR TITLE
Make Temporal polyfill import conditional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hebcal/noaa",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hebcal/noaa",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "LGPL-2.1",
       "dependencies": {
         "temporal-polyfill": "^0.3.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,9 @@
         "gts": "^7.0.0",
         "typedoc": "^0.28.18",
         "typescript": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hebcal/noaa",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "sunrise and sunset via NOAA algorithm with elevation, based on KosherJava",
   "author": "Michael J. Radwin (https://github.com/mjradwin)",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
   "files": [
     "dist/*"
   ],
+  "engines": {
+    "node": ">=20"
+  },
   "devDependencies": {
     "@types/node": "25.6.0",
     "ava": "^7.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
-import 'temporal-polyfill/global';
+if (typeof (globalThis as {Temporal?: unknown}).Temporal === 'undefined') {
+  await import('temporal-polyfill/global');
+}
 
 /**
  * java.lang.Math.toRadians


### PR DESCRIPTION
## Summary
Changed the Temporal polyfill import to be conditional, only loading it when the Temporal API is not already available in the global scope.

## Key Changes
- Replaced unconditional `import 'temporal-polyfill/global'` with a runtime check that uses dynamic `await import()` only when `globalThis.Temporal` is undefined
- This prevents unnecessary polyfill loading in environments that already have native Temporal support
- Updated package version to 0.11.0

## Implementation Details
The change uses a type-safe check `typeof (globalThis as {Temporal?: unknown}).Temporal === 'undefined'` to determine if the polyfill needs to be loaded, enabling tree-shaking and reducing bundle size for modern environments with native Temporal API support.

https://claude.ai/code/session_01RHgtGBjE9KvGJ5aaf3cVb4